### PR TITLE
Provide generic list of tool statuses

### DIFF
--- a/acserver/urls.py
+++ b/acserver/urls.py
@@ -24,4 +24,6 @@ urlpatterns = patterns('',
     url(r'^(?P<tool_id>\d+)/tooluse/time/for/(?P<card_id>[a-fA-F0-9]+)/(?P<duration>[0-9]+)$', 'server.views.settoolusetime'),
 #/api/get_tools_summary_for_user/1
     url(r'^api/get_tools_summary_for_user/(?P<user_id>[0-9]+)$', 'server.views.get_tools_summary_for_user'),
+#/api/get_tools_status
+    url(r'^api/get_tools_status$', 'server.views.get_tools_status'),
 )

--- a/server/views.py
+++ b/server/views.py
@@ -311,3 +311,16 @@ def get_tools_summary_for_user(request, user_id):
     ret.append({'name': t.name, 'status': t.get_status_display(), 'status_message' : t.status_message, 'in_use' : t.get_inuse_display(), 'permission' : perm})
 
   return HttpResponse(json.dumps(ret), content_type='text/plain')
+
+
+# settings.ACS_API_KEY
+# HttpRequest.META
+@require_api_key
+@require_GET
+def get_tools_status(request):
+  ret = []
+  # [{u'status': u'Operational', u'status_message': u'working ok', u'name': u'test_tool', u'in_use': u'no'}]
+  for t in Tool.objects.order_by('pk'):
+    ret.append({'name': t.name, 'status': t.get_status_display(), 'status_message' : t.status_message, 'in_use' : t.get_inuse_display()})
+
+  return HttpResponse(json.dumps(ret), content_type='application/json')


### PR DESCRIPTION
This will allow querying for tool status without logging in (since it's not necessary to know a user's specific rights). Needs to be merged before the equivalent pull request in londonhackspace/hackspace-foundation-sites.

This provides the same API as the equivalent pull request in londonhackspace/acserver.
